### PR TITLE
Fix typo in new `reload.rs` docs

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -7,7 +7,7 @@
 //! not instantaneous -- it takes time to run `cargo metadata` and (for proc
 //! macros) `cargo check`.
 //!
-//! The main guiding principle here is, as elsewhere in rust-analyzer, is
+//! The main guiding principle here, as elsewhere in rust-analyzer, is
 //! robustness. We try not to assume that the project model exists or is
 //! correct. Instead, we try to provide a best-effort service. Even if the
 //! project is currently loading and we don't have a full project model, we


### PR DESCRIPTION
Just skimmed today's changelog and came across the repetition